### PR TITLE
新增API-refreshToken, 修改token帶的資訊

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -92,6 +92,14 @@ module.exports = {
     if (!auth) return next(appError(400, '您的密碼不正確', next));
     generateSendJWT(user, 200, res);
   }),
+  // 更新token
+  refreshToken: handleError(async (req, res, next) => {
+    const userID = req.user.id;
+    if (!userID) return appError(400, 'user id 未帶入', next);
+    const user = await User.findById(userID);
+    if (user == null) return next(appError(400, '查無資料', next));
+    generateSendJWT(user, 200, res);
+  }),
   // 取得登入者個人資訊
   ownProfile: handleError(async (req, res, next) => {
     const userID = req.user;

--- a/handStates/auth.js
+++ b/handStates/auth.js
@@ -39,6 +39,7 @@ const generateSendJWT = (user, statusCode, res) => {
       userName: user.userName,
       userPhoto: user.userPhoto,
       gender: user.gender,
+      premiumMember: user.premiumMember.paid === 1,
     },
     process.env.JWT_SECRET,
     {
@@ -54,6 +55,7 @@ const generateSendJWT = (user, statusCode, res) => {
       userName: user.userName,
       userPhoto: user.userPhoto,
       gender: user.gender,
+      premiumMember: user.premiumMember.paid === 1,
     },
   });
 };
@@ -66,6 +68,7 @@ const generateRedirectJWT = (user, res) => {
       userName: user.userName,
       userPhoto: user.userPhoto,
       gender: user.gender,
+      premiumMember: user.premiumMember.paid === 1,
     },
     process.env.JWT_SECRET,
     {

--- a/routes/users.js
+++ b/routes/users.js
@@ -75,6 +75,8 @@ router.post('/login', (req, res, next) =>
           "token": "Token",
           "name": "王小明",
           "userPhoto": "https://avatars.githubusercontent.com/u/42748910?v=4",
+          "gender": "male",
+          "premiumMember": true
         }
       }
     },
@@ -116,6 +118,35 @@ router.post('/signUp', (req, res, next) =>
     }
   */
   UsersControllers.signUp(req, res, next)
+);
+router.post(
+  '/refreshToken',
+  isAuth,
+  /** #swagger.summary = '更新token'
+    #swagger.description = `
+      <ul>
+        <li>取得 Token 至上方 Authorize 按鈕以格式 <code>Bearer ＜Token＞</code> 加入設定，swagger 文件中鎖頭上鎖表示登入，可使用登入權限。</li>
+      </ul>
+    `,
+    * #swagger.tags = ['users (使用者)']
+    * #swagger.security = [{
+      'apiKeyAuth': []
+    }],
+    * #swagger.responses[200] = {
+      description: '同登入的資訊',
+      schema: {
+        status: 'success',
+        data: {
+          "token": "Token",
+          "name": "王小明",
+          "userPhoto": "https://avatars.githubusercontent.com/u/42748910?v=4",
+          "gender": "male",
+          "premiumMember": true
+        }
+      }
+    },
+  */
+  UsersControllers.refreshToken
 );
 router.get(
   '/ownProfile',


### PR DESCRIPTION
**新增API-refreshToken**
功能：用舊的token換新的
`{{url}}/users/refreshToken`

**修改token帶的資訊**
將premiumMember資訊也包進token中
僅提供true/false，詳細資訊還是打ownProfile取得